### PR TITLE
Force garbage collection after model run

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -10,6 +10,7 @@ dependencies:
   - scipy>=1.4
   - cudatoolkit=11.2
   - cudnn=8.1.0
+  - click
   - pip
   - pip:
     - tensorflow==2.6.2

--- a/src/python/ifcb_features/scripts/process_bins.py
+++ b/src/python/ifcb_features/scripts/process_bins.py
@@ -4,6 +4,7 @@ import logging
 import os
 from pathlib import Path
 from zipfile import ZipFile
+import gc
 
 import click
 import h5py as h5
@@ -114,6 +115,10 @@ def process_bin(
             if classify_images:
                 logging.info(f'Classifying images and saving to {class_fname}')
                 predictions_df = classify.predict(model_config, image_stack)
+
+                # Since classify.predict (which calls Model.predict) is run in a for loop, memory consumption 
+                # will build up and result in an OOM error, so we excplicitly clear it out after each model run.
+                gc.collect()  
 
                 # Save predictions to h5
                 predictions2h5(model_config, class_fname, predictions_df, bin.lid, features_df)


### PR DESCRIPTION
Switching the image stack from `uint8` to `float64` revealed that GPU memory wasn't being freed, resulting in OOM errors as the objects kept accumulating across iterations. This fixes that by calling `gc.collect()` directly.